### PR TITLE
Fix for latest pywin32

### DIFF
--- a/mast/installer/files/linux/mast
+++ b/mast/installer/files/linux/mast
@@ -1,9 +1,8 @@
 #!/usr/bin/env sh
 
 export MAST_HOME=<%MAST_HOME%>
-export PYTHONPATH=<%MAST_HOME%>/anaconda/lib/python2.7:<%MAST_HOME%>/anaconda/lib/python2.7/site-packages:<%MAST_HOME%>/anaconda/lib:<%MAST_HOME%>/bin:<%MAST_HOME%>/var:<%MAST_HOME%>:$PATH
-
 cd $MAST_HOME
+source ./set-env
 
 if [ $# -eq 0 ]; then
     anaconda/bin/ipython

--- a/mast/installer/files/windows/mast.bat
+++ b/mast/installer/files/windows/mast.bat
@@ -3,6 +3,7 @@
 SET MAST_HOME=<%MAST_HOME%>
 
 cd /d %MAST_HOME%
+set-env.bat
 
 if "%~1"=="" (
   %MAST_HOME%\anaconda\Scripts\ipython


### PR DESCRIPTION
This calls `set-env.bat` on Windows in `mast.bat` and for completeness sake calls `source ./set-env` in `mast` on Linux.

This should fix the issue with the latest build of PyWin32 where continuum moved the `.dll` files to be on the PATH, but since we don't permanently modify the user's PATH we need to set it on each invocation.

@briankearney @mharden108 @steveyeof 

Please review