### PR TITLE
fix for build-hotfix not properly install dulwich

### DIFF
--- a/mast/installer/files/contrib/build-hotfix.py
+++ b/mast/installer/files/contrib/build-hotfix.py
@@ -153,7 +153,7 @@ def main():
         logger.info(msg)
         print msg
         os.chdir(d)
-        if d == "dulwich":
+        if "dulwich" in d:
             out, err = system_call([python, "setup.py", "--pure", "install", "--force"])
         else:
             out, err = system_call(command)


### PR DESCRIPTION
an "IF" statement was looking for a literal path of "dulwich" instead of checking to see if the path contained a "dulwich" string